### PR TITLE
Don't prepend '/' to paths on Windows

### DIFF
--- a/R/ressource_route.R
+++ b/R/ressource_route.R
@@ -166,6 +166,6 @@ ressource_route <- function(..., default_file = 'index.html', default_ext = 'htm
 }
 
 complete_paths <- function(paths) {
-  paths <- ifelse(grepl('^/', paths), paths, paste0('/', paths))
+  paths <- ifelse(grepl('^/', paths) | .Platform$OS.type == "windows", paths, paste0('/', paths))
   ifelse(grepl('/$', paths), paths, paste0(paths, '/'))
 }


### PR DESCRIPTION
On Windows, prepending '/' on `complete_paths` creates invalid paths, e.g.

    > routr:::complete_paths('C:/Users')
    [1] "/C:/Users/"

This commit simply adds a test if R is running on Windows, and if so, the beginning of the path is left untouched.